### PR TITLE
fix(faq): handle long answers with safe interaction replies

### DIFF
--- a/src/modules/faq/utils/faqCommand.ts
+++ b/src/modules/faq/utils/faqCommand.ts
@@ -1,14 +1,25 @@
 import {
   type ChatInputCommandInteraction,
+  heading,
+  HeadingLevel,
+  hyperlink,
   MessageFlags,
   SlashCommandBuilder,
 } from 'discord.js';
 
 import { getMentionComponent } from '@/common/components/mention.js';
-import { commandDescriptions, commandErrors } from '@/translations/commands.js';
+import { safeReplyToInteraction } from '@/common/utils/messages.js';
+import {
+  commandDescriptions,
+  commandErrors,
+  commandResponseFunctions,
+} from '@/translations/commands.js';
 
 import { getQuestionComponent } from '../components/components.js';
+import { getNormalizedUrl } from './links.js';
 import { getClosestQuestion } from './search.js';
+
+const MAX_COMPONENT_TEXT_LENGTH = 4_000;
 
 export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
   data: new SlashCommandBuilder()
@@ -38,6 +49,27 @@ export const getCommonCommand = (name: keyof typeof commandDescriptions) => ({
 
     if (question === null) {
       await interaction.editReply(commandErrors.faqNotFound);
+
+      return;
+    }
+
+    const title = heading(question.name, HeadingLevel.Two);
+    const mention = user ? commandResponseFunctions.commandFor(user.id) : '';
+
+    if (
+      title.length + question.content.length + mention.length >
+      MAX_COMPONENT_TEXT_LENGTH
+    ) {
+      const links = Object.entries(question.links ?? {})
+        .filter(([name, url]) => name !== '' && url !== '')
+        .map(([name, url]) => hyperlink(name, getNormalizedUrl(url)))
+        .join('\n');
+
+      await safeReplyToInteraction(
+        interaction,
+        [mention, title, question.content, links].filter(Boolean).join('\n\n'),
+        { mentionUsers: user !== null },
+      );
 
       return;
     }

--- a/test/modules/faq/faqCommand.test.ts
+++ b/test/modules/faq/faqCommand.test.ts
@@ -1,0 +1,106 @@
+import { type ChatInputCommandInteraction, MessageFlags } from 'discord.js';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+import type { Question } from '@/modules/faq/schemas/Question.js';
+
+import { getCommonCommand } from '@/modules/faq/utils/faqCommand.js';
+import { commandResponseFunctions } from '@/translations/commands.js';
+
+const mocks = vi.hoisted(() => ({
+  getClosestQuestion: vi.fn<() => Promise<null | Question>>(),
+}));
+
+vi.mock('@/modules/faq/utils/search.js', () => ({
+  getClosestQuestion: mocks.getClosestQuestion,
+}));
+
+const createInteraction = (userId: null | string = null) => {
+  const editReply = vi.fn<(payload: unknown) => Promise<void>>(async () => {});
+  const followUp = vi.fn<(payload: unknown) => Promise<void>>(async () => {});
+  const interaction = {
+    deferred: true,
+    editReply,
+    followUp,
+    options: {
+      getString: () => 'FAQ',
+      getUser: () => (userId ? { id: userId } : null),
+    },
+  } as unknown as ChatInputCommandInteraction;
+
+  return { editReply, followUp, interaction };
+};
+
+const setQuestion = (content: string, links: Question['links'] = null) => {
+  mocks.getClosestQuestion.mockResolvedValue({
+    content,
+    createdAt: Temporal.Instant.from('2026-09-11T00:00:00Z'),
+    distance: undefined,
+    id: 'faq-question',
+    links,
+    name: 'FAQ',
+    updatedAt: Temporal.Instant.from('2026-09-11T00:00:00Z'),
+    userId: null,
+  });
+};
+
+describe('/faq long answers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('keeps components at the combined 4000-character boundary', async () => {
+    setQuestion('a'.repeat(3_994));
+    const { editReply, followUp, interaction } = createInteraction();
+
+    await getCommonCommand('faq').execute(interaction);
+
+    expect(editReply).toHaveBeenCalledWith({
+      components: [expect.anything()],
+      flags: MessageFlags.IsComponentsV2,
+    });
+    expect(followUp).not.toHaveBeenCalled();
+  });
+
+  test.each([3_995, 4_281])(
+    'sends a %i-character answer in full through the existing reply helper',
+    async (length: number) => {
+      const content = 'а'.repeat(length);
+      setQuestion(content, {
+        '': 'ignored.example',
+        Guide: 'example.com/guide',
+      });
+      const { editReply, followUp, interaction } = createInteraction();
+
+      await getCommonCommand('faq').execute(interaction);
+
+      const payloads = [...editReply.mock.calls, ...followUp.mock.calls].map(
+        ([payload]) => payload as { content: string; flags?: number },
+      );
+      expect(followUp).toHaveBeenCalled();
+      expect(payloads.map((payload) => payload.content).join('')).toBe(
+        `## FAQ\n\n${content}\n\n[Guide](https://example.com/guide)`,
+      );
+      for (const payload of payloads) {
+        expect(payload.content.length).toBeLessThanOrEqual(2_000);
+        expect(payload.flags).toBeUndefined();
+      }
+    },
+  );
+
+  test('includes mention overhead in the budget and sends the mention once', async () => {
+    setQuestion('a'.repeat(3_994));
+    const userId = '123456789012345678';
+    const { editReply, followUp, interaction } = createInteraction(userId);
+
+    await getCommonCommand('faq').execute(interaction);
+
+    const contents = [...editReply.mock.calls, ...followUp.mock.calls].map(
+      ([payload]) => (payload as { content: string }).content,
+    );
+    expect(contents[0]).toBe(
+      `${commandResponseFunctions.commandFor(userId)}\n\n## FAQ\n\n`,
+    );
+    expect(contents.join('').split(`<@${userId}>`)).toHaveLength(2);
+    expect(followUp).toHaveBeenCalled();
+  });
+});

--- a/test/modules/faq/faqCommand.test.ts
+++ b/test/modules/faq/faqCommand.test.ts
@@ -7,7 +7,8 @@ import { getCommonCommand } from '@/modules/faq/utils/faqCommand.js';
 import { commandResponseFunctions } from '@/translations/commands.js';
 
 const mocks = vi.hoisted(() => ({
-  getClosestQuestion: vi.fn<() => Promise<null | Question>>(),
+  getClosestQuestion:
+    vi.fn<() => Promise<null | Pick<Question, 'content' | 'links' | 'name'>>>(),
 }));
 
 vi.mock('@/modules/faq/utils/search.js', () => ({
@@ -33,13 +34,8 @@ const createInteraction = (userId: null | string = null) => {
 const setQuestion = (content: string, links: Question['links'] = null) => {
   mocks.getClosestQuestion.mockResolvedValue({
     content,
-    createdAt: Temporal.Instant.from('2026-09-11T00:00:00Z'),
-    distance: undefined,
-    id: 'faq-question',
     links,
     name: 'FAQ',
-    updatedAt: Temporal.Instant.from('2026-09-11T00:00:00Z'),
-    userId: null,
   });
 };
 


### PR DESCRIPTION
## Summary
- Fix `/faq` failing on long answers by reusing `safeReplyToInteraction`.
- Preserve full text, mentions, and links; keep the component layout for answers that fit.
- Add regression coverage for length boundaries and the reported 4,281-character answer.

## Verification
CI passes: tests, ESLint, TypeScript, security analysis, and both Docker builds.
